### PR TITLE
Add healthchecks for production jobs

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -120,3 +120,8 @@ www.{{ config "inyoka-media-domain" }} {
 	redir https://{{ config "inyoka-media-domain" }}{uri}
 	import common
 }
+
+# used for docker health check
+http://localhost:2024 {
+	respond "caddy works"
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,12 @@ x-django:
   volumes:
     - media-files:/srv/www/media
 
+x-healthcheck-defaults:
+  &healthcheck_defaults
+  # https://docs.docker.com/reference/dockerfile/#healthcheck
+  timeout: 1m
+  start_period: 10s
+
 
 services:
   postgres:
@@ -51,11 +57,16 @@ services:
         target: /dev/shm
         tmpfs:
           size: 268435456
-
+    healthcheck:
+      <<: *healthcheck_defaults
+      test: ['CMD', 'pg_isready']
 
   inyoka-worker:
     << : *default-django
     command: /inyoka/venv/bin/gunicorn -b 0.0.0.0:8000 --workers 24 --max-requests 500 inyoka.wsgi:application
+    healthcheck:
+      <<: *healthcheck_defaults
+      test: python -c 'import http.client; conn = http.client.HTTPConnection("localhost", 8000); conn.request("GET", "/"); res = conn.getresponse(); assert len(res.read()) > 0'
 
   redis:
     image: docker.io/library/redis:7.2.9-alpine
@@ -70,16 +81,25 @@ services:
       - inyoka-redis-password
     volumes:
       - redis-data:/data
+    healthcheck:
+      <<: *healthcheck_defaults
+      test: nc -z 127.0.0.1 6379
 
   celeryworker:
     << : *default-django
     command: /inyoka/venv/bin/celery --app=inyoka worker --loglevel=INFO --concurrency=8
+    healthcheck:
+      <<: *healthcheck_defaults
+      test: ['CMD-SHELL', 'cat /proc/1/cmdline | grep --text "celery" | grep --text "worker" || false']
 
   celerybeat:
     << : *default-django
     command: /inyoka/venv/bin/celery --app=inyoka beat --pidfile /tmp/celerybeat.pid --loglevel=INFO --schedule /volume/celerybeat-schedule/celerybeat-schedule
     volumes:
       - celerybeat-schedule:/volume/celerybeat-schedule
+    healthcheck:
+      <<: *healthcheck_defaults
+      test: ['CMD-SHELL', 'cat /proc/1/cmdline | grep --text "celery" | grep --text "beat" || false']
 
   caddy:
     image: git.ubuntu-eu.org/ubuntuusers/caddy-inyoka
@@ -94,7 +114,9 @@ services:
       - inyoka-base-domain
       - inyoka-media-domain
       - inyoka-static-domain
-
+    healthcheck:
+      <<: *healthcheck_defaults
+      test: ['CMD-SHELL', 'wget http://localhost:2024 -O - -o /dev/null']
 
 configs:
   inyoka-config:


### PR DESCRIPTION
For caddy a new address is added that only targets localhost. Otherwise we would need the adjustable hostname to check if a connection is possible (or rely on something like netstat).

Fix https://github.com/inyokaproject/docker-setup/issues/3